### PR TITLE
Add `?sourcemap` query

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Other supported options of [esbuild](https://esbuild.github.io/):
   ```javascript
   import React from "https://esm.sh/react?ignore-annotations"
   ```
+- [Sourcemap](https://esbuild.github.io/api/#sourcemap)
+  ```javascript
+  import React from "https://esm.sh/react?sourcemap"
+  ```
+  
+  This only supports the `inline` mode.
 
 ### Package CSS
 

--- a/server/build.go
+++ b/server/build.go
@@ -33,6 +33,7 @@ type BuildTask struct {
 	NoRequire         bool
 	KeepNames         bool
 	IgnoreAnnotations bool
+	Sourcemap         bool
 
 	// state
 	id    string
@@ -60,6 +61,9 @@ func (task *BuildTask) ID() string {
 	}
 	if task.IgnoreAnnotations {
 		name += ".ia"
+	}
+	if task.Sourcemap {
+		name += ".sm"
 	}
 	if task.DevMode {
 		name += ".development"
@@ -389,6 +393,9 @@ esbuild:
 		options.Platform = api.PlatformNode
 	} else {
 		options.Define = define
+	}
+	if (task.Sourcemap) {
+		options.Sourcemap = 1
 	}
 	if entryPoint != "" {
 		options.EntryPoints = []string{entryPoint}

--- a/server/query.go
+++ b/server/query.go
@@ -442,6 +442,7 @@ func query(devMode bool) rex.Handle {
 		noRequire := ctx.Form.Has("no-require")
 		keepNames := ctx.Form.Has("keep-names")
 		ignoreAnnotations := ctx.Form.Has("ignore-annotations")
+		sourcemap := ctx.Form.Has("sourcemap")
 
 		// force react/jsx-dev-runtime and react-refresh into `dev` mode
 		if !isDev {
@@ -497,6 +498,10 @@ func query(devMode bool) rex.Handle {
 					if endsWith(submodule, ".kn") {
 						submodule = strings.TrimSuffix(submodule, ".kn")
 						keepNames = true
+					}
+					if endsWith(submodule, ".sm") {
+						submodule = strings.TrimSuffix(submodule, ".sm")
+						sourcemap = true
 					}
 					if endsWith(submodule, ".nr") {
 						submodule = strings.TrimSuffix(submodule, ".nr")
@@ -589,6 +594,7 @@ func query(devMode bool) rex.Handle {
 			NoRequire:         noRequire,
 			KeepNames:         keepNames,
 			IgnoreAnnotations: ignoreAnnotations,
+			Sourcemap:         sourcemap,
 			stage:             "init",
 		}
 		taskID := task.ID()


### PR DESCRIPTION
This pull request adds a `?sourcemap` query, which should make debugging scripts imported from esm.sh easier.

Due to the way esm.sh works, it is made into a boolean and supports `inline` mode only.