### PR TITLE
Add npm private packages support

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -43,6 +43,7 @@ Server options:
 - `dbUrl` - the database url (default is `postdb:$etcDir/esm.db`)
 - `origin` - the origin of the CDN
 - `npmRegistry` - the npm registry (default is https://npmjs.org/registry)
+- `npmToken` - the private token for npm registry
 
 ## Deploy with Docker
 

--- a/server/build.go
+++ b/server/build.go
@@ -122,8 +122,6 @@ func (task *BuildTask) Build() (esm *ESM, err error) {
 				0644,
 			)
 
-			fmt.Println("File path:", rcFilePath)
-
 			if err != nil {
 				log.Errorf("Failed to create .mpmrc file: %v", err)
 				return

--- a/server/build.go
+++ b/server/build.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -111,6 +112,23 @@ func (task *BuildTask) Build() (esm *ESM, err error) {
 		hasher.Write([]byte(task.ID()))
 		task.wd = path.Join(os.TempDir(), fmt.Sprintf("esm-build-%s-%s", hex.EncodeToString(hasher.Sum(nil)), rs.Hex.String(8)))
 		ensureDir(task.wd)
+
+		rcFilePath := path.Join(task.wd, ".npmrc")
+
+		if !fileExists(rcFilePath) {
+			err = ioutil.WriteFile(
+				rcFilePath,
+				[]byte("_authToken=${ESM_NPM_TOKEN}"),
+				0644,
+			)
+
+			fmt.Println("File path:", rcFilePath)
+
+			if err != nil {
+				log.Errorf("Failed to create .mpmrc file: %v", err)
+				return
+			}
+		}
 	}
 	defer func() {
 		err := os.RemoveAll(task.wd)

--- a/server/node_services.go
+++ b/server/node_services.go
@@ -112,6 +112,7 @@ func startNodeServices(etcDir string, port int) (err error) {
 		[]byte(fmt.Sprintf(nsApp, port)),
 		0644,
 	)
+
 	if err != nil {
 		return
 	}

--- a/server/nodejs.go
+++ b/server/nodejs.go
@@ -610,10 +610,8 @@ func yarnAdd(wd string, packages ...string) (err error) {
 
 		cmd := exec.Command("yarn", append(args, packages...)...)
 
-		if node.npmToken != "" {
-			cmd.Env = os.Environ()
-			cmd.Env = append(cmd.Env, "ESM_NPM_TOKEN="+node.npmToken)
-		}
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, "ESM_NPM_TOKEN="+node.npmToken)
 
 		cmd.Dir = wd
 

--- a/server/nodejs.go
+++ b/server/nodejs.go
@@ -186,11 +186,12 @@ type NpmPackage struct {
 // Node defines the nodejs info
 type Node struct {
 	version     string
+	npmToken    string
 	npmRegistry string
 	yarn        string
 }
 
-func checkNode(installDir string, npmRegistry string) (node *Node, err error) {
+func checkNode(installDir string, npmRegistry string, npmToken string) (node *Node, err error) {
 	var installed bool
 CheckNodejs:
 	version, major, err := getNodejsVersion()
@@ -232,6 +233,10 @@ CheckNodejs:
 		if err == nil {
 			node.npmRegistry = strings.TrimRight(strings.TrimSpace(string(output)), "/") + "/"
 		}
+	}
+
+	if npmToken != "" {
+		node.npmToken = npmToken
 	}
 
 CheckYarn:
@@ -316,7 +321,16 @@ func fetchPackageInfo(name string, version string) (info NpmPackage, err error) 
 	defer lock.Delete(id)
 
 	start := time.Now()
-	resp, err := httpClient.Get(node.npmRegistry + name)
+	req, err := http.NewRequest("GET", node.npmRegistry+name, nil)
+	if err != nil {
+		return
+	}
+	if node.npmToken != "" {
+		req.Header.Set("Authorization", "Bearer "+node.npmToken)
+	}
+
+	resp, err := httpClient.Do(req)
+
 	if err != nil {
 		return
 	}
@@ -578,7 +592,6 @@ func yarnAdd(wd string, packages ...string) (err error) {
 			"--ignore-scripts",
 			"--ignore-workspace-root-check",
 			"--no-bin-links",
-			"--no-default-rc",
 			"--no-lockfile",
 			"--no-node-version-check",
 			"--no-progress",
@@ -594,8 +607,16 @@ func yarnAdd(wd string, packages ...string) (err error) {
 		if yarnMutex != "" {
 			args = append(args, "--mutex", yarnMutex)
 		}
+
 		cmd := exec.Command("yarn", append(args, packages...)...)
+
+		if node.npmToken != "" {
+			cmd.Env = os.Environ()
+			cmd.Env = append(cmd.Env, "ESM_NPM_TOKEN="+node.npmToken)
+		}
+
 		cmd.Dir = wd
+
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("yarn add %s: %s", strings.Join(packages, ","), string(output))

--- a/server/server.go
+++ b/server/server.go
@@ -49,6 +49,7 @@ func Serve(efs EmbedFS) {
 		origin           string
 		basePath         string
 		npmRegistry      string
+		npmToken         string
 		unpkgOrigin      string
 		noCompress       bool
 		isDev            bool
@@ -66,6 +67,7 @@ func Serve(efs EmbedFS) {
 	flag.StringVar(&origin, "origin", "", "the server origin, default is the request host")
 	flag.StringVar(&basePath, "base-path", "", "the base path")
 	flag.StringVar(&npmRegistry, "npm-registry", "", "the npm registry")
+	flag.StringVar(&npmToken, "npm-token", "", "the npm token for private responstries")
 	flag.StringVar(&unpkgOrigin, "unpkg-origin", "https://unpkg.com", "the unpkg.com origin")
 	flag.BoolVar(&noCompress, "no-compress", false, "to disable the compression for text content")
 	flag.BoolVar(&isDev, "dev", false, "to run server in development mode")
@@ -116,7 +118,7 @@ func Serve(efs EmbedFS) {
 	if nodeInstallDir == "" {
 		nodeInstallDir = path.Join(etcDir, "nodejs")
 	}
-	node, err = checkNode(nodeInstallDir, npmRegistry)
+	node, err = checkNode(nodeInstallDir, npmRegistry, npmToken)
 	if err != nil {
 		log.Fatalf("check nodejs env: %v", err)
 	}


### PR DESCRIPTION
## Background
For the business case, I want to self-hosting this server and serve with some private packages hosted on the npm-registry  

## Changes
- Add the `npm-token` flag to provide NPM private token 
- Add the `.npmrc` file in the temporary yarn installing directory to provide the `_authToken`
- Remove the `--no-default-rc` flag of the `yarn installing` command to support reading `.npmrc`