### PR TITLE
Use cross-fetch instead of node-fetch-native in browser

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -581,12 +581,19 @@ esbuild:
 				if importPath == "" && task.external.Has("*") {
 					importPath = name
 				}
-				// use `node-fetch-naitve` instead of `node-fetch`
+				// use `node-fetch-native` instead of `node-fetch`
 				if importPath == "" && name == "node-fetch" && task.Target != "node" {
-					importPath = task.getImportPath(Pkg{
-						Name:    "node-fetch-native",
-						Version: "0.1.3",
-					}, "")
+					if task.Target == "deno" {
+						importPath = task.getImportPath(Pkg{
+							Name:    "node-fetch-native",
+							Version: "0.1.3",
+						}, "")
+					} else {
+						importPath = task.getImportPath(Pkg{
+							Name:    "cross-fetch",
+							Version: "3.1.5",
+						}, "")
+					}
 				}
 				// use version defined in `?deps` query
 				if importPath == "" {


### PR DESCRIPTION
fixes #422

Packages that import `node-fetch` don't work in the browser because `node-fetch-native` imports `worker_threads`, which does not have an available polyfill. Use `cross-fetch` instead when targeting the browser.

Tested by importing packages `@notionhq/client` and `@tensorflow/tfjs` in the browser and see that they work.