### PR TITLE
Fix scenarios where module/es2015 are shims (maps)

### DIFF
--- a/server/nodejs.go
+++ b/server/nodejs.go
@@ -166,6 +166,66 @@ type NpmPackageVerions struct {
 	Versions map[string]NpmPackage `json:"versions"`
 }
 
+func (a *NpmPackage) UnmarshalJSON(b []byte) error {
+	var n NpmPackageTemp
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	*a = *n.ToNpmPackage()
+	return nil
+}
+
+type StringOrMap struct {
+	Value string
+	Map   map[string]string
+}
+
+func (a *StringOrMap) UnmarshalJSON(b []byte) error {
+	if err := json.Unmarshal(b, &a.Value); err != nil {
+		if err := json.Unmarshal(b, &a.Map); err != nil {
+			return err
+		}
+	}
+	// TODO: Set Value to first element of map if it exists
+	return nil
+}
+
+// NpmPackageTemp defines the package.json of npm
+type NpmPackageTemp struct {
+	Name             string                 `json:"name"`
+	Version          string                 `json:"version"`
+	Type             string                 `json:"type,omitempty"`
+	Main             string                 `json:"main,omitempty"`
+	Module           StringOrMap            `json:"module,omitempty"`
+	JsNextMain       string                 `json:"jsnext:main,omitempty"`
+	ES2015           StringOrMap            `json:"es2015,omitempty"`
+	Types            string                 `json:"types,omitempty"`
+	Typings          string                 `json:"typings,omitempty"`
+	Dependencies     map[string]string      `json:"dependencies,omitempty"`
+	PeerDependencies map[string]string      `json:"peerDependencies,omitempty"`
+	Imports          map[string]interface{} `json:"imports,omitempty"`
+	DefinedExports   interface{}            `json:"exports,omitempty"`
+	// todo: support `browser` field
+}
+
+func (a *NpmPackageTemp) ToNpmPackage() *NpmPackage {
+	return &NpmPackage{
+		Name:             a.Name,
+		Version:          a.Version,
+		Type:             a.Type,
+		Main:             a.Main,
+		Module:           a.Module.Value,
+		JsNextMain:       a.JsNextMain,
+		ES2015:           a.ES2015.Value,
+		Types:            a.Types,
+		Typings:          a.Typings,
+		Dependencies:     a.Dependencies,
+		PeerDependencies: a.PeerDependencies,
+		Imports:          a.Imports,
+		DefinedExports:   a.DefinedExports,
+	}
+}
+
 // NpmPackage defines the package.json of npm
 type NpmPackage struct {
 	Name             string                 `json:"name"`

--- a/test/baseui/baseui.test.ts
+++ b/test/baseui/baseui.test.ts
@@ -1,0 +1,8 @@
+import { assertEquals } from "https://deno.land/std@0.162.0/testing/asserts.ts";
+
+import {createTheme} from "http://localhost:8080/baseui@12.2.0";
+
+Deno.test("baseui", () => {
+  assertEquals(typeof createTheme, "function");
+});
+


### PR DESCRIPTION
In some cases, package.json (e.g. baseui from https://baseweb.design/) contains the following shims: 

```json
      "module": "./dist/index.es.js",
      "browser": {
        "./dist/index.js": "./dist/browser.es5.js",
        "./dist/index.es.js": "./dist/browser.es5.es.js"
      },
      "es2015": {
        "./dist/browser.es5.es.js": "./dist/browser.es2015.es.js"
      },
      "es2017": {
        "./dist/browser.es5.es.js": "./dist/browser.es2017.es.js",
        "./dist/browser.es2015.es.js": "./dist/browser.es2017.es.js"
      },
```

I believe the behavior is defined in https://github.com/defunctzombie/package-browser-field-spec . 

In such scenarios, esm.sh will fail to un-marshal the package spec.
This attempts to fix it.

The hot fix here is quite naive. It doesn't actually respect the shim. Other approaches are potentially using generics or `json.RawMessage`.
The real fix might be to traverse and pick the latest es version. Though my guess is that implementations that have these sophisticated shims may also have `module` set, so the actual impact of doing a full traversal/resolution of shims may have very little impact on real-world use cases.

In my usage, I just needed to get the JSON to be unmarshaled, and everything else seemed to work fine.