### PR TITLE
fix: upgrade go version to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module esm.sh
 
-go 1.16
+go 1.18
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0
@@ -15,4 +15,34 @@ require (
 	github.com/ije/postdb v0.7.1
 	github.com/ije/rex v1.8.4
 	github.com/mssola/user_agent v0.5.3
+)
+
+require (
+	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.1 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.11.2 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.3 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.9 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.3 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.10 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.11.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.16.3 // indirect
+	github.com/aws/smithy-go v1.11.2 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/rs/cors v1.8.2 // indirect
+	github.com/rs/xid v1.3.0 // indirect
+	go.etcd.io/bbolt v1.3.6 // indirect
+	golang.org/x/crypto v0.4.0 // indirect
+	golang.org/x/net v0.3.0 // indirect
+	golang.org/x/sys v0.3.0 // indirect
+	golang.org/x/text v0.5.0 // indirect
 )


### PR DESCRIPTION
# Background
The go version is not correctly set, the 1.16 is too stale to run the server since some dependencies are required at least 1.17.
![image](https://user-images.githubusercontent.com/11769853/207495202-16287652-37df-4fdd-a118-a231e1dd0edb.png)

# Changes
Upgrade to 1.18 (as same as the Dockerfile)

# Test
successfully run the server with the 1.18 at my local
<img width="1196" alt="image" src="https://user-images.githubusercontent.com/11769853/207495718-6ff92936-03c5-4f68-98aa-52afe84b8c91.png">
