### PR TITLE
fix(conf): some bugs related to package path parsing

### DIFF
--- a/config.example.jsonc
+++ b/config.example.jsonc
@@ -39,8 +39,8 @@
   // The base path of server, default is "/".
   "basePath": "/",
 
-  // The npm registry, default is "https://registry.npmjs.org".
-  "npmRegistry": "https://registry.npmjs.org",
+  // The npm registry, default is "https://registry.npmjs.org/".
+  "npmRegistry": "https://registry.npmjs.org/",
 
   // The npm token for private packages, default is blank.
   "npmToken": "",

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -72,6 +72,7 @@ func Load(filename string) (*Config, error) {
 			return nil, fmt.Errorf("fail to get absolute path of the work directory: %w", err)
 		}
 	}
+	cfg.BasePath = strings.TrimRight(cfg.BasePath, "/")
 	if cfg.Port == 0 {
 		cfg.Port = 8080
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -78,7 +78,7 @@ func esmHandler() rex.Handle {
 
 		// Build prefix may only be served from "${cfg.BasePath}/..."
 		if cfg.BasePath != "" {
-			if strings.HasPrefix(pathname, cfg.BasePath+"/") {
+			if strings.HasPrefix(pathname, cfg.BasePath) {
 				pathname = strings.TrimPrefix(pathname, cfg.BasePath)
 			} else {
 				url := strings.TrimPrefix(ctx.R.URL.String(), cfg.BasePath)

--- a/server/nodejs.go
+++ b/server/nodejs.go
@@ -387,7 +387,7 @@ func fetchPackageInfo(name string, version string) (info NpmPackage, err error) 
 	defer lock.Delete(id)
 
 	start := time.Now()
-	req, err := http.NewRequest("GET", cfg.NpmRegistry+name, nil)
+	req, err := http.NewRequest("GET", strings.TrimRight(cfg.NpmRegistry,"/")+"/"+name, nil)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
./config.json:
```
  "basePath": "/",
  "npmRegistry": "https://registry.npmjs.org",
```

Bad Cases:
```
$ curl -D- http://localhost:8080/react
HTTP/1.1 302 Found
...
Location: //react

$ curl -D- http://localhost:8080/react@18.2.0
HTTP/1.1 302 Found
...
Location: http://localhost:8080//react@18.2.0

$ curl -D- http://localhost:8080/react
----server error------------
Get "https://registry.npmjs.orgreact": dial tcp: lookup registry.npmjs.orgreact: no such host
```