### PR TITLE
respect externals arg in bundle mode

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -299,10 +299,10 @@ func (task *BuildTask) build(tracing *stringSet) (esm *ESM, err error) {
 					}
 
 					// bundles all dependencies in `bundle` mode, apart from peer dependencies
-					if task.BundleMode && !extraExternal.Has(specifier) {
+					if task.BundleMode && !extraExternal.Has(specifier) && !task.external.Has(specifier) {
 						pkgNameInfo := parsePkgPath(specifier)
 						if !builtInNodeModules[pkgNameInfo.Name] {
-							_, ok := npm.PeerDependencies[pkgNameInfo.Name]
+							_, ok := npm.PeerDependencies[pkgNameInfo.Fullname]
 							if !ok {
 								return api.OnResolveResult{}, nil
 							}

--- a/test/external-bundle/ajv.test.tsx
+++ b/test/external-bundle/ajv.test.tsx
@@ -7,7 +7,6 @@ function use(arg: any) {
 }
 
 Deno.test("external-bundle", async () => {
-  use(ajv)
+  use(ajv) //hack to prevent unused import removal
   assert((globalThis as any).ourDeepEqImported === true)
-  // assert(html == "<main><p>just now</p></main>");
 });

--- a/test/external-bundle/ajv.test.tsx
+++ b/test/external-bundle/ajv.test.tsx
@@ -1,0 +1,13 @@
+import { assert } from "https://deno.land/std@0.170.0/testing/asserts.ts";
+
+import * as ajv from 'http://localhost:8080/ajv@8.12.0?bundle&external=fast-deep-equal'
+
+function use(arg: any) {
+
+}
+
+Deno.test("external-bundle", async () => {
+  use(ajv)
+  assert((globalThis as any).ourDeepEqImported === true)
+  // assert(html == "<main><p>just now</p></main>");
+});

--- a/test/external-bundle/deep-eq.js
+++ b/test/external-bundle/deep-eq.js
@@ -1,0 +1,5 @@
+globalThis.ourDeepEqImported = true;
+
+export default () => {
+    throw new Error('not impl')
+}

--- a/test/external-bundle/deno.json
+++ b/test/external-bundle/deno.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "deno.ns"
+    ]
+  },
+  "importMap": "./import_map.json"
+}

--- a/test/external-bundle/import_map.json
+++ b/test/external-bundle/import_map.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "fast-deep-equal": "./deep-eq.js",
+    "json-schema-traverse": "./not-existed-file-should-throw.js"
+  }
+}


### PR DESCRIPTION
fixes #498 
I'm not sure this is correct. I see that default flow is go through 
```go
return api.OnResolveResult{Path: "__ESM_SH_EXTERNAL:" + url, External: true}, nil
```
Then rewrite imports in output files after go compiled it. Don't know why is that. 
