### PR TITLE
Default export all members from original module to prevent missing named exports members

### DIFF
--- a/server/build.go
+++ b/server/build.go
@@ -198,7 +198,7 @@ func (task *BuildTask) build(marker *stringSet) (esm *ESM, err error) {
 		importPath := task.Pkg.ImportPath()
 		fmt.Fprintf(buf, `import * as __module from "%s";`, importPath)
 		// Default reexport all members from original module to prevent missing named exports members
-		fmt.Fprintf(buf, `export * from "%s"`, importPath)
+		fmt.Fprintf(buf, `export * from "%s";`, importPath)
 		if len(esm.Exports) > 0 {
 			var exports []string
 			for _, k := range esm.Exports {

--- a/server/build.go
+++ b/server/build.go
@@ -197,6 +197,8 @@ func (task *BuildTask) build(marker *stringSet) (esm *ESM, err error) {
 		buf := bytes.NewBuffer(nil)
 		importPath := task.Pkg.ImportPath()
 		fmt.Fprintf(buf, `import * as __module from "%s";`, importPath)
+		// Default reexport all members from original module to prevent missing named exports members
+		fmt.Fprintf(buf, `export * from "%s"`, importPath)
 		if len(esm.Exports) > 0 {
 			var exports []string
 			for _, k := range esm.Exports {

--- a/test/export-all-members/rc-utils.test.tsx
+++ b/test/export-all-members/rc-utils.test.tsx
@@ -1,0 +1,10 @@
+import { assertExists } from "https://deno.land/std@0.170.0/testing/asserts.ts";
+
+import * as dynamicCSS from "http://localhost:8080/rc-util@5.27.2/es/Dom/dynamicCSS.js";
+
+Deno.test("Export all members when the package is not a standard ES module", async () => {
+    assertExists(dynamicCSS.updateCSS);
+    assertExists(dynamicCSS.injectCSS);
+    assertExists(dynamicCSS.removeCSS);
+    assertExists(dynamicCSS.clearContainerCache);
+});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7475347/219301765-fed3ed93-e8e9-4529-bffc-2a59c37ad6e6.png)

https://unpkg.com/rc-util@5.27.2/es/Dom/dynamicCSS.js 
https://esm.sh/v106/rc-util@5.27.2/es2022/es/Dom/dynamicCSS.js
The module is exported members but will be moved to the default export
![image](https://user-images.githubusercontent.com/7475347/219302743-ea0cff43-7571-43e9-ab98-f7862926c1c7.png)
Add the reexport members to fix this problem
![image](https://user-images.githubusercontent.com/7475347/219303101-d6e81e45-0597-4dcd-b9ab-2e3cd478671b.png)


