### PR TITLE
Remove patch for preact/compat types

### DIFF
--- a/server/dts_transform.go
+++ b/server/dts_transform.go
@@ -341,12 +341,14 @@ func (task *BuildTask) transformDTS(dts string, aliasDepsPrefix string, marker *
 	// fix preact/compat types
 	if pkgName == "preact" && strings.HasSuffix(savePath, "/compat/src/index.d.ts") {
 		dtsData := buf.Bytes()
-		dtsData = bytes.ReplaceAll(
-			dtsData,
-			[]byte("export import ComponentProps = preact.ComponentProps;"),
-			[]byte("export import ComponentProps = preact.ComponentProps;\n\n// added by esm.sh\nexport type PropsWithChildren<P = unknown> = P & { children?: preact.ComponentChildren };"),
-		)
-		buf = bytes.NewBuffer(dtsData)
+		if !bytes.Contains(dtsData, []byte("export type PropsWithChildren")) {
+			dtsData = bytes.ReplaceAll(
+				dtsData,
+				[]byte("export import ComponentProps = preact.ComponentProps;"),
+				[]byte("export import ComponentProps = preact.ComponentProps;\n\n// added by esm.sh\nexport type PropsWithChildren<P = unknown> = P & { children?: preact.ComponentChildren };"),
+			)
+			buf = bytes.NewBuffer(dtsData)
+		}
 	}
 
 	_, err = fs.WriteFile(savePath, buf)


### PR DESCRIPTION
This patch is causing issues with recent versions of Preact:

```
error: TS2300 [ERROR]: Duplicate identifier 'PropsWithChildren'.
export type PropsWithChildren<P = unknown> = P & { children?: preact.ComponentChildren };
            ~~~~~~~~~~~~~~~~~
    at https://esm.sh/v106/preact@10.12.1/compat/src/index.d.ts:56:13

TS2300 [ERROR]: Duplicate identifier 'PropsWithChildren'.
	export type PropsWithChildren<P = unknown> = P & {
	            ~~~~~~~~~~~~~~~~~
    at https://esm.sh/v106/preact@10.12.1/compat/src/index.d.ts:149:14
```